### PR TITLE
fix: check aux length to avoid exception

### DIFF
--- a/lwm/data.py
+++ b/lwm/data.py
@@ -155,7 +155,7 @@ class VisionTextProcessor(object):
             example, *aux = example
         else:
             aux = tuple()
-        rand_state = random.Random(aux[-1]) # makes augmentations deterministic by line number
+        rand_state = random.Random(aux[-1] if aux else 0) # makes augmentations deterministic by line number
         token_buffer = []
         loss_mask_buffer = []
         vision_mask = []


### PR DESCRIPTION
if aux is set to tuple() in the line above, aux[-1] will throw exception. `aux[-1] if aux else 0` will ensure aux is not None and its length is not 0